### PR TITLE
fix: error running file on osx

### DIFF
--- a/modules/data.lua
+++ b/modules/data.lua
@@ -642,7 +642,7 @@ function data.init_module()
 	]]
 
 	if ffi.os == "OSX" then
-		obsffi = ffi.load("obs.0.dylib"); -- OS X
+		obsffi = ffi.load("obs-opengl.dylib"); -- OS X
 	else
 		obsffi = ffi.load("obs"); -- Windows
 		-- Linux?


### PR DESCRIPTION
Using the script in OBS 30.0.2 on macOS 14.3, i got this error:
```log
[OBS-Stats-on-Stream.lua] Error running file: [string "my-obs-scripts-path/OBS-Stats-on..."]:1164: dlopen(libobs.0.dylib, 0x0005): tried: 'libobs.0.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OSlibobs.0.dylib' (no such file), '/Applications/OBS.app/Contents/Frameworks/libobs.0.dylib' (no such file), '/Applications/OBS.app/Contents/Frameworks/libobs.0.dylib' (no such file), '/usr/lib/libobs.0.dylib' (no such file, not in dyld cache), 'libobs.0.dylib' (no such file), '/usr/local/lib/libobs.0.dylib' (no such file), '/usr/lib/libobs.0.dylib' (no such file, not in dyld cache)
```
Should be `libobs-opengl.dylib`, which is found inside `.app` content.
![image](https://github.com/GreenComfyTea/OBS-Stats-on-Stream/assets/21117946/5e8cf22b-8b69-46c1-899d-0b5c03665761)
